### PR TITLE
Add support for unknown colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,14 +18,10 @@ The repository is organized into four main components:
 
 ## Progress
 
-- [x] Interpreter: functionally complete for all images with correct pixel colors.  
+- [x] Interpreter: functionally complete, supports treating unknown colors as white / black.
 - [x] Compiler: functionally complete and correct to my knowledge, with white block tracing / elimination implemented as well as support for running LLVM module optimization passes. To read more about the compiler, visit this [page](https://github.com/pwang00/pietcc/blob/main/Compiler.md).  
 
 ## TODO
-
-Interpreter: 
-
-* Add functionality to allow treating unknown colors as white / black
 
 Compiler:
 
@@ -106,7 +102,7 @@ FizzBuzz
 
 Doing `cargo run --release images/fizzbuzz.png -i -v 2` will also work.
 
-## Compiling Piet Programs
+## Compiling Piet programs
 
 PietCC supports emitting executables, LLVM IR, and LLVM bitcode.  The latter two options can be useful for targeting other architectures other than x86_64. The relevant flags are shown below.
 

--- a/parser/src/convert.rs
+++ b/parser/src/convert.rs
@@ -1,9 +1,17 @@
 use image::Rgb;
+use std::panic;
 use types::color::{Hue::*, Lightness, Lightness::*};
+use UnknownPixelSettings::*;
 
+#[derive(Copy, Clone)]
+pub enum UnknownPixelSettings {
+    TreatAsError,
+    TreatAsWhite,
+    TreatAsBlack,
+}
 // I feel like converting pixels to lightness would make the code more maintainable
 pub trait ConvertToLightness {
-    fn rgb_to_lightness(pixel: &Rgb<u8>) -> Lightness {
+    fn rgb_to_lightness(pixel: &Rgb<u8>, settings: UnknownPixelSettings) -> Lightness {
         match pixel.0 {
             [0x00, 0x00, 0x00] => Black,
             [0xFF, 0xFF, 0xFF] => White,
@@ -25,7 +33,11 @@ pub trait ConvertToLightness {
             [0x00, 0xC0, 0xC0] => Dark(Cyan),
             [0x00, 0x00, 0xC0] => Dark(Blue),
             [0xC0, 0x00, 0xC0] => Dark(Magenta),
-            _ => panic!("Invalid pixel encountered! {:?}", pixel.0),
+            _ => match settings {
+                TreatAsError => panic!("Invalid pixel encountered! {:?}", pixel.0),
+                TreatAsWhite => White,
+                TreatAsBlack => Black,
+            },
         }
     }
 }

--- a/parser/src/decode.rs
+++ b/parser/src/decode.rs
@@ -39,20 +39,20 @@ mod test_parse {
     struct Test;
     impl DecodeInstruction for Test {}
     impl ConvertToLightness for Test {}
-
+    const SETTINGS: UnknownPixelSettings = UnknownPixelSettings::TreatAsError;
     #[test]
     fn test_convert_hue_change() {
         let pix1 = Rgb::<u8>([0xFF, 0xC0, 0xFF]);
         let pix2 = Rgb::<u8>([0xC0, 0xC0, 0xFF]);
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), Some(Instruction::Add));
 
         let pix1 = Rgb::<u8>([0xFF, 0xC0, 0xFF]);
         let pix2 = Rgb::<u8>([0xC0, 0xFF, 0xFF]);
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), Some(Instruction::Div))
     }
@@ -61,15 +61,15 @@ mod test_parse {
     fn test_convert_lightness_change() {
         let pix1 = Rgb::<u8>([0xFF, 0xC0, 0xC0]);
         let pix2 = Rgb::<u8>([0xFF, 0x00, 0x00]);
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), Some(Instruction::Push));
 
         let pix1 = Rgb::<u8>([0xFF, 0xC0, 0xC0]);
         let pix2 = Rgb::<u8>([0xC0, 0x00, 0x00]);
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), Some(Instruction::Pop))
     }
@@ -78,8 +78,8 @@ mod test_parse {
     fn test_convert_hue_lightness_change() {
         let pix1 = Rgb::<u8>([0xFF, 0xC0, 0xFF]);
         let pix2 = Rgb::<u8>([0xC0, 0x00, 0x00]);
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         println!("{:?}, {:?}", l1, l2);
         println!("{:?}", l1 - l2);
@@ -92,8 +92,8 @@ mod test_parse {
         let pix1 = Rgb::<u8>([0xFF, 0xFF, 0xFF]);
         let pix2 = Rgb::<u8>([0xC0, 0xC0, 0xFF]);
 
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), None);
     }
@@ -103,8 +103,8 @@ mod test_parse {
         let pix1 = Rgb::<u8>([0x00, 0x00, 0x00]);
         let pix2 = Rgb::<u8>([0xC0, 0xC0, 0xFF]);
 
-        let l1 = Test::rgb_to_lightness(&pix1);
-        let l2 = Test::rgb_to_lightness(&pix2);
+        let l1 = Test::rgb_to_lightness(&pix1, SETTINGS);
+        let l2 = Test::rgb_to_lightness(&pix2, SETTINGS);
 
         assert_eq!(Test::decode_instr(l1, l2), None);
     }

--- a/parser/src/loader.rs
+++ b/parser/src/loader.rs
@@ -1,4 +1,4 @@
-use crate::convert::ConvertToLightness;
+use crate::convert::{ConvertToLightness, UnknownPixelSettings};
 use image::ImageError;
 use types::program::Program;
 pub struct Loader;
@@ -6,13 +6,16 @@ pub struct Loader;
 impl ConvertToLightness for Loader {}
 
 impl Loader {
-    pub fn convert<'a>(filename: &str) -> Result<Program<'a>, ImageError> {
+    pub fn convert<'a>(
+        filename: &str,
+        settings: UnknownPixelSettings,
+    ) -> Result<Program<'a>, ImageError> {
         let img = image::open(filename)?.into_rgb8();
         let (w, h) = img.dimensions();
 
         let leaked = Box::leak(Box::new(
             img.pixels()
-                .map(<Self as ConvertToLightness>::rgb_to_lightness)
+                .map(|pix| <Self as ConvertToLightness>::rgb_to_lightness(pix, settings))
                 .collect::<Vec<_>>(),
         ));
 


### PR DESCRIPTION
Can now supply --uw, --ub flags to treat unknown colors as white / black, respectively.